### PR TITLE
refactor: mediator recipient cleanup

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -131,7 +131,7 @@ export class Agent {
   public async init() {
     await this.wallet.init()
 
-    const { publicDidSeed } = this.agentConfig
+    const { publicDidSeed, mediatorConnectionsInvite } = this.agentConfig
     if (publicDidSeed) {
       // If an agent has publicDid it will be used as routing key.
       await this.wallet.initPublicDid({ seed: publicDidSeed })
@@ -141,20 +141,34 @@ export class Agent {
       await this.inboundTransporter.start(this)
     }
 
-    await this.mediationRecipient.init(this.connections)
+    // Connect to mediator through provided invitation if provided in config
+    // Also requests mediation ans sets as default mediator
+    // Because this requires the connections module, we do this in the agent constructor
+    if (mediatorConnectionsInvite) {
+      // Assumption: processInvitation is a URL-encoded invitation
+      let connectionRecord = await this.connections.receiveInvitationFromUrl(mediatorConnectionsInvite, {
+        autoAcceptConnection: true,
+      })
+
+      // TODO: add timeout to returnWhenIsConnected
+      connectionRecord = await this.connections.returnWhenIsConnected(connectionRecord.id)
+      const mediationRecord = await this.mediationRecipient.requestAndAwaitGrant(connectionRecord, 60000) // TODO: put timeout as a config parameter
+      await this.mediationRecipient.setDefaultMediator(mediationRecord)
+    }
+
+    await this.mediationRecipient.initialize()
+
     this._isInitialized = true
   }
 
   public get publicDid() {
     return this.wallet.publicDid
   }
-  public async getMediatorUrl() {
-    const defaultMediator = await this.mediationRecipient.getDefaultMediator()
-    return defaultMediator?.endpoint ?? this.agentConfig.getEndpoint()
-  }
+
   public get port() {
     return this.agentConfig.port
   }
+
   public async receiveMessage(inboundPackedMessage: unknown, session?: TransportSession) {
     return await this.messageReceiver.receiveMessage(inboundPackedMessage, session)
   }

--- a/src/modules/connections/services/ConnectionService.ts
+++ b/src/modules/connections/services/ConnectionService.ts
@@ -199,9 +199,9 @@ export class ConnectionService {
       throw new AriesFrameworkError('Invalid message')
     }
 
-    connectionRecord.theirDid = message.connection.did
     connectionRecord.theirDidDoc = message.connection.didDoc
     connectionRecord.threadId = message.id
+    connectionRecord.theirDid = message.connection.did
 
     if (!connectionRecord.theirKey) {
       throw new AriesFrameworkError(`Connection with id ${connectionRecord.id} has no recipient keys.`)

--- a/src/modules/routing/RecipientModule.ts
+++ b/src/modules/routing/RecipientModule.ts
@@ -69,7 +69,7 @@ export class RecipientModule {
   }
 
   public async downloadMessages(mediatorConnection: ConnectionRecord) {
-    let connection = mediatorConnection ?? (await this.getDefaultMediatorConnection())
+    let connection = mediatorConnection ?? (await this.findDefaultMediatorConnection())
     connection = assertConnection(connection, 'connection not found for default mediator')
     const batchPickupMessage = new BatchPickupMessage({ batchSize: 10 })
     const outboundMessage = createOutboundMessage(connection, batchPickupMessage)

--- a/src/modules/routing/RoutingEvents.ts
+++ b/src/modules/routing/RoutingEvents.ts
@@ -14,7 +14,7 @@ export interface MediationStateChangedEvent extends BaseEvent {
   type: typeof RoutingEventTypes.MediationStateChanged
   payload: {
     mediationRecord: MediationRecord
-    previousState: MediationState
+    previousState: MediationState | null
   }
 }
 

--- a/src/modules/routing/__tests__/RecipientService.test.ts
+++ b/src/modules/routing/__tests__/RecipientService.test.ts
@@ -46,6 +46,7 @@ describe('Recipient', () => {
       const record = new MediationRecord({
         state: MediationState.Init,
         role: MediationRole.Recipient,
+        threadId: 'fakeThreadId',
         connectionId: 'fakeConnectionId',
         recipientKeys: ['fakeRecipientKey'],
         tags: {

--- a/src/modules/routing/__tests__/RecipientService.test.ts
+++ b/src/modules/routing/__tests__/RecipientService.test.ts
@@ -49,10 +49,7 @@ describe('Recipient', () => {
         connectionId: 'fakeConnectionId',
         recipientKeys: ['fakeRecipientKey'],
         tags: {
-          state: MediationState.Init,
-          role: MediationRole.Recipient,
-          connectionId: 'fakeConnectionId',
-          default: 'false',
+          default: false,
         },
       })
       assert(record.state, 'Expected MediationRecord to have an `state` property')
@@ -76,8 +73,7 @@ describe('Recipient', () => {
   describe('Recipient service tests', () => {
     it('validate service class signiture', () => {
       assert(recipientService.setDefaultMediator, 'Expected RecipientService to have a `setDefaultMediator` method')
-      assert(recipientService.getDefaultMediator, 'Expected RecipientService to have a `getDefaultMediator` method')
-      assert(recipientService.getDefaultMediatorId, 'Expected RecipientService to have a `getDefaultMediatorId` method')
+      assert(recipientService.findDefaultMediator, 'Expected RecipientService to have a `getDefaultMediator` method')
       assert(recipientService.getMediators, 'Expected RecipientService to have a `getMediators` method')
       assert(recipientService.clearDefaultMediator, 'Expected RecipientService to have a `clearDefaultMediator` method')
       assert(recipientService.findByConnectionId, 'Expected RecipientService to have a `findByConnectionId` method')

--- a/src/modules/routing/handlers/KeylistUpdateHandler.ts
+++ b/src/modules/routing/handlers/KeylistUpdateHandler.ts
@@ -1,6 +1,7 @@
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { MediatorService } from '../services/MediatorService'
 
+import { createOutboundMessage } from '../../../agent/helpers'
 import { AriesFrameworkError } from '../../../error'
 import { KeylistUpdateMessage } from '../messages'
 
@@ -16,6 +17,8 @@ export class KeylistUpdateHandler implements Handler {
     if (!messageContext.connection) {
       throw new AriesFrameworkError(`Connection for verkey ${messageContext.recipientVerkey} not found!`)
     }
-    return await this.mediatorService.processKeylistUpdateRequest(messageContext)
+
+    const response = await this.mediatorService.processKeylistUpdateRequest(messageContext)
+    return createOutboundMessage(messageContext.connection, response)
   }
 }

--- a/src/modules/routing/messages/KeylistUpdateResponseMessage.ts
+++ b/src/modules/routing/messages/KeylistUpdateResponseMessage.ts
@@ -10,6 +10,7 @@ import { RoutingMessageType as MessageType } from './RoutingMessageType'
 export interface KeylistUpdateResponseMessageOptions {
   id?: string
   keylist: KeylistUpdated[]
+  threadId: string
 }
 
 /**
@@ -24,6 +25,9 @@ export class KeylistUpdateResponseMessage extends AgentMessage {
     if (options) {
       this.id = options.id || this.generateId()
       this.updated = options.keylist
+      this.setThread({
+        threadId: options.threadId,
+      })
     }
   }
 

--- a/src/modules/routing/messages/MediationGrantMessage.ts
+++ b/src/modules/routing/messages/MediationGrantMessage.ts
@@ -8,9 +8,10 @@ import { AgentMessage } from '../../../agent/AgentMessage'
 import { RoutingMessageType as MessageType } from './RoutingMessageType'
 
 export interface MediationGrantMessageOptions {
-  id: string
+  id?: string
   endpoint: string
   routingKeys: Verkey[]
+  threadId: string
 }
 
 /**
@@ -24,9 +25,12 @@ export class MediationGrantMessage extends AgentMessage {
     super()
 
     if (options) {
-      this.id = options.id
+      this.id = options.id ?? this.generateId()
       this.endpoint = options.endpoint
       this.routingKeys = options.routingKeys
+      this.setThread({
+        threadId: options.threadId,
+      })
     }
   }
 

--- a/src/modules/routing/repository/MediationRecord.ts
+++ b/src/modules/routing/repository/MediationRecord.ts
@@ -12,6 +12,7 @@ export interface MediationRecordProps {
   role: MediationRole
   createdAt?: Date
   connectionId: string
+  threadId: string
   endpoint?: string
   recipientKeys?: Verkey[]
   routingKeys?: Verkey[]
@@ -26,6 +27,7 @@ export type DefaultMediationTags = {
   role: MediationRole
   connectionId: string
   state: MediationState
+  threadId: string
 }
 
 export class MediationRecord
@@ -35,6 +37,7 @@ export class MediationRecord
   public state!: MediationState
   public role!: MediationRole
   public connectionId!: string
+  public threadId!: string
   public endpoint?: string
   public recipientKeys!: Verkey[]
   public routingKeys!: Verkey[]
@@ -49,6 +52,7 @@ export class MediationRecord
       this.id = props.id ?? uuid()
       this.createdAt = props.createdAt ?? new Date()
       this.connectionId = props.connectionId
+      this.threadId = props.threadId
       this.recipientKeys = props.recipientKeys || []
       this.routingKeys = props.routingKeys || []
       this.state = props.state || MediationState.Init
@@ -57,12 +61,14 @@ export class MediationRecord
     }
   }
 
-  public getTags(): { state: MediationState; role: MediationRole; connectionId: string } {
+  public getTags() {
     return {
       ...this._tags,
       state: this.state,
       role: this.role,
       connectionId: this.connectionId,
+      threadId: this.threadId,
+      recipientKeys: this.recipientKeys,
     }
   }
 

--- a/src/modules/routing/repository/MediationRecord.ts
+++ b/src/modules/routing/repository/MediationRecord.ts
@@ -1,4 +1,3 @@
-import type { TagsBase } from '../../../storage/BaseRecord'
 import type { MediationRole } from '../models/MediationRole'
 import type { Verkey } from 'indy-sdk'
 
@@ -16,11 +15,13 @@ export interface MediationRecordProps {
   endpoint?: string
   recipientKeys?: Verkey[]
   routingKeys?: Verkey[]
-  default?: boolean
   tags?: CustomMediationTags
 }
 
-export type CustomMediationTags = TagsBase
+export type CustomMediationTags = {
+  default?: boolean
+}
+
 export type DefaultMediationTags = {
   role: MediationRole
   connectionId: string
@@ -37,7 +38,7 @@ export class MediationRecord
   public endpoint?: string
   public recipientKeys!: Verkey[]
   public routingKeys!: Verkey[]
-  public default = false
+
   public static readonly type = 'MediationRecord'
   public readonly type = MediationRecord.type
 
@@ -53,7 +54,6 @@ export class MediationRecord
       this.state = props.state || MediationState.Init
       this.role = props.role
       this.endpoint = props.endpoint ?? undefined
-      this.default = props.default || false
     }
   }
 
@@ -65,6 +65,7 @@ export class MediationRecord
       connectionId: this.connectionId,
     }
   }
+
   public assertState(expectedStates: MediationState | MediationState[]) {
     if (!Array.isArray(expectedStates)) {
       expectedStates = [expectedStates]

--- a/src/modules/routing/repository/MediationRepository.ts
+++ b/src/modules/routing/repository/MediationRepository.ts
@@ -11,4 +11,13 @@ export class MediationRepository extends Repository<MediationRecord> {
   public constructor(@inject(InjectionSymbols.StorageService) storageService: StorageService<MediationRecord>) {
     super(MediationRecord, storageService)
   }
+
+  public findByRecipientKey(recipientKey: string) {
+    // TODO: would be nice if the query method could automatically handle arrays
+    const tag = `recipientKey:${recipientKey}`
+
+    return this.findSingleByQuery({
+      [tag]: true,
+    })
+  }
 }

--- a/src/modules/routing/services/RecipientService.ts
+++ b/src/modules/routing/services/RecipientService.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from '../../../agent/AgentMessage'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import type { ConnectionRecord } from '../../connections'
 import type { MediationStateChangedEvent, KeylistUpdatedEvent } from '../RoutingEvents'
@@ -12,6 +13,7 @@ import { EventEmitter } from '../../../agent/EventEmitter'
 import { MessageSender } from '../../../agent/MessageSender'
 import { createOutboundMessage } from '../../../agent/helpers'
 import { InjectionSymbols } from '../../../constants'
+import { AriesFrameworkError } from '../../../error'
 import { Wallet } from '../../../wallet/Wallet'
 import { ConnectionService } from '../../connections/services/ConnectionService'
 import { RoutingEventTypes } from '../RoutingEvents'
@@ -50,29 +52,17 @@ export class RecipientService {
     this.messageSender = messageSender
   }
 
-  public async init() {
-    const records = await this.mediatorRepository.getAll()
-    for (const record of records) {
-      if (record.default) {
-        // Remove any possible competing mediators set all other record tags' default to false.
-        this.setDefaultMediator(record)
-        return this.defaultMediator
-      }
-    }
-  }
-
-  public async createRequest(connection: ConnectionRecord): Promise<[MediationRecord, MediationRequestMessage]> {
+  public async createRequest(
+    connection: ConnectionRecord
+  ): Promise<MediationProtocolMsgReturnType<MediationRequestMessage>> {
     const mediationRecord = new MediationRecord({
       state: MediationState.Requested,
       role: MediationRole.Mediator,
       connectionId: connection.id,
-      tags: {
-        role: MediationRole.Mediator,
-        connectionId: connection.id,
-      },
     })
     await this.mediatorRepository.save(mediationRecord)
-    return [mediationRecord, new MediationRequestMessage({})]
+
+    return { mediationRecord, message: new MediationRequestMessage({}) }
   }
 
   public async processMediationGrant(messageContext: InboundMessageContext<MediationGrantMessage>) {
@@ -256,87 +246,63 @@ export class RecipientService {
   }
 
   public async findById(id: string): Promise<MediationRecord | null> {
-    try {
-      const record = await this.mediatorRepository.findById(id)
-      return record
-    } catch (error) {
-      return null
-    }
-    // TODO - Handle errors?
+    return this.mediatorRepository.findById(id)
   }
 
   public async findByConnectionId(connectionId: string): Promise<MediationRecord | null> {
-    try {
-      const records = await this.mediatorRepository.findByQuery({ connectionId })
-      return records[0]
-    } catch (error) {
-      return null
-    }
+    return this.mediatorRepository.findSingleByQuery({ connectionId })
   }
 
-  public async getMediators(): Promise<MediationRecord[] | null> {
-    return await this.mediatorRepository.getAll()
+  public async getMediators(): Promise<MediationRecord[]> {
+    return this.mediatorRepository.getAll()
   }
 
-  public async getDefaultMediatorId(): Promise<string | undefined> {
-    if (this.defaultMediator) {
-      return this.defaultMediator.id
-    }
-    const record = await this.getDefaultMediator()
-    return record ? record.id : undefined
-  }
-
-  public async getDefaultMediator() {
-    if (!this.defaultMediator) {
-      const records = (await this.mediatorRepository.getAll()) ?? []
-      for (const record of records) {
-        if (record.default) {
-          this.setDefaultMediator(record)
-          return this.defaultMediator
-        }
-      }
-    }
-    return this.defaultMediator
+  public async findDefaultMediator(): Promise<MediationRecord | null> {
+    return this.mediatorRepository.findSingleByQuery({ default: true })
   }
 
   public async discoverMediation(mediatorId?: string): Promise<MediationRecord | undefined> {
+    // If mediatorId is passed, always use it (and error if it is not found)
     if (mediatorId) {
-      const mediationRecord = await this.findById(mediatorId)
-      if (mediationRecord) {
-        return mediationRecord
-      }
+      return this.mediatorRepository.getById(mediatorId)
     }
 
-    const defaultMediator = await this.getDefaultMediator()
+    const defaultMediator = await this.findDefaultMediator()
     if (defaultMediator) {
       if (defaultMediator.state !== MediationState.Granted) {
-        throw new Error(`Mediation State for ${defaultMediator.id} is not granted, but is set as default mediator!`)
+        throw new AriesFrameworkError(
+          `Mediation State for ${defaultMediator.id} is not granted, but is set as default mediator!`
+        )
       }
+
       return defaultMediator
     }
   }
 
   public async setDefaultMediator(mediator: MediationRecord) {
-    // Get list of all mediator records. For each record, update default all others to false.
-    const fetchedRecords = (await this.getMediators()) ?? []
+    const mediationRecords = await this.mediatorRepository.findByQuery({ default: true })
 
-    for (const record of fetchedRecords) {
-      record.default = false
+    for (const record of mediationRecords) {
+      record.setTag('default', false)
       await this.mediatorRepository.update(record)
     }
+
     // Set record coming in tag to true and then update.
-    mediator.default = true
+    mediator.setTag('default', true)
     await this.mediatorRepository.update(mediator)
-    this.defaultMediator = mediator
-    return this.defaultMediator
   }
 
   public async clearDefaultMediator() {
-    const fetchedRecords = (await this.getMediators()) ?? []
-    for (const record of fetchedRecords) {
-      record.default = false
-      await this.mediatorRepository.update(record)
+    const mediationRecord = await this.findDefaultMediator()
+
+    if (mediationRecord) {
+      mediationRecord.setTag('default', false)
+      await this.mediatorRepository.update(mediationRecord)
     }
-    delete this.defaultMediator
   }
+}
+
+export interface MediationProtocolMsgReturnType<MessageType extends AgentMessage> {
+  message: MessageType
+  mediationRecord: MediationRecord
 }

--- a/src/modules/routing/services/RoutingService.ts
+++ b/src/modules/routing/services/RoutingService.ts
@@ -80,10 +80,6 @@ export async function createRecord(
     role,
     connectionId,
     recipientKeys,
-    tags: {
-      role,
-      connectionId,
-    },
   })
   await mediatorRepository.save(mediationRecord)
   return mediationRecord

--- a/src/modules/routing/services/RoutingService.ts
+++ b/src/modules/routing/services/RoutingService.ts
@@ -4,11 +4,8 @@
 import type { EventEmitter } from '../../../agent/EventEmitter'
 import type { BaseEvent } from '../../../agent/Events'
 import type { ConnectionRecord } from '../../connections/repository/ConnectionRecord'
-import type { MediationRecordProps } from '../repository/MediationRecord'
-import type { MediationRepository } from '../repository/MediationRepository'
 
 import { AriesFrameworkError } from '../../../error/AriesFrameworkError'
-import { MediationRecord } from '../repository/MediationRecord'
 
 /**
  * waitForEvent
@@ -71,19 +68,6 @@ export const waitForEvent = async (
   })
 }
 /* eslint-enable */
-export async function createRecord(
-  { state, role, connectionId, recipientKeys }: MediationRecordProps,
-  mediatorRepository: MediationRepository
-): Promise<MediationRecord> {
-  const mediationRecord = new MediationRecord({
-    state,
-    role,
-    connectionId,
-    recipientKeys,
-  })
-  await mediatorRepository.save(mediationRecord)
-  return mediationRecord
-}
 
 export function assertConnection(
   record: ConnectionRecord | undefined,

--- a/src/storage/BaseRecord.ts
+++ b/src/storage/BaseRecord.ts
@@ -1,6 +1,6 @@
 import { Exclude, Type } from 'class-transformer'
 
-export type TagValue = string | boolean | undefined
+export type TagValue = string | boolean | undefined | Array<string>
 export type TagsBase = {
   [key: string]: TagValue
   [key: number]: never

--- a/src/storage/IndyStorageService.ts
+++ b/src/storage/IndyStorageService.ts
@@ -29,7 +29,17 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
     for (const [key, value] of Object.entries(tags)) {
       // If the value is a boolean string ('1' or '0')
       // use the boolean val
-      if (value === '1' || value === '0') {
+      if (value === '1' && value?.includes(':')) {
+        const [tagName, tagValue] = value.split(':')
+
+        const transformedValue = transformedTags[tagName]
+
+        if (Array.isArray(transformedValue)) {
+          transformedTags[tagName] = [...transformedValue, tagValue]
+        } else {
+          transformedTags[tagName] = [tagValue]
+        }
+      } else if (value === '1' || value === '0') {
         transformedTags[key] = value === '1'
       }
       // Otherwise just use the value
@@ -49,6 +59,14 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
       // '1' or '0' syntax
       if (isBoolean(value)) {
         transformedTags[key] = value ? '1' : '0'
+      }
+      // If the value is an array we create a tag for each array
+      // item ("tagName:arrayItem" = "1")
+      else if (Array.isArray(value)) {
+        value.forEach((item) => {
+          const tagName = `${key}:${item}`
+          transformedTags[tagName] = '1'
+        })
       }
       // Otherwise just use the value
       else {

--- a/src/transport/PollingInboundTransporter.ts
+++ b/src/transport/PollingInboundTransporter.ts
@@ -24,7 +24,7 @@ export class PollingInboundTransporter implements InboundTransporter {
   private async pollDownloadMessages(agent: Agent) {
     setInterval(async () => {
       if (!this.stop) {
-        const connection = await agent.mediationRecipient.getDefaultMediatorConnection()
+        const connection = await agent.mediationRecipient.findDefaultMediatorConnection()
         if (connection && connection.state == ConnectionState.Complete) {
           await agent.mediationRecipient.downloadMessages(connection)
         }
@@ -65,7 +65,7 @@ export class TrustPingPollingInboundTransporter implements InboundTransporter {
   private async pollDownloadMessages(recipient: Agent) {
     setInterval(async () => {
       if (this.run) {
-        const connection = await recipient.mediationRecipient.getDefaultMediatorConnection()
+        const connection = await recipient.mediationRecipient.findDefaultMediatorConnection()
         if (connection && connection.state == 'complete') {
           /*ping mediator uses a trust ping to trigger any stored messages to be sent back, one at a time.*/
           await this.pingMediator(connection)

--- a/src/transport/WsInboundTransporter.ts
+++ b/src/transport/WsInboundTransporter.ts
@@ -24,7 +24,7 @@ export class WsInboundTransporter implements InboundTransporter {
   }
   public async start() {
     /** nothing to see here*/
-    const defaultMediator = await this.agent.mediationRecipient.getDefaultMediatorConnection()
+    const defaultMediator = await this.agent.mediationRecipient.findDefaultMediatorConnection()
     if (defaultMediator) {
       // TODO: update with batch pickup protocol.
       this.trustPingSocket(defaultMediator)
@@ -60,9 +60,9 @@ export class WsInboundTransporter implements InboundTransporter {
     }
     socket.onopen = async () => {
       this.logger.trace('Socket has been opened')
-      const mediator = await this.agent.mediationRecipient.getDefaultMediatorConnection()
-      this.logger.debug('Mediator connection record being used:', mediator)
+      const mediator = await this.agent.mediationRecipient.findDefaultMediatorConnection()
       if (mediator) {
+        this.logger.debug('Mediator connection record being used:', mediator)
         const ping = await this.preparePing(mediator, { responseRequested: false })
         this.logger.trace('Sending ping to socket with mediator connection encryption:', ping)
         const packed = await this.messageSender.packOutBoundMessage(ping)


### PR DESCRIPTION
@burdettadam some cleanup in the recipient module

- move default mediation invite handling to agent initialization. This removed the requirement to pass the connections modules. We can refactor later, but for now this is fine I think.
- do not loop through all mediation records to retrieve or set the default mediation record (but use a `default` tag instead)
- use `findXXX` instead of `getXXX` for records that can return null